### PR TITLE
Feat: 질문하기 버튼 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
+import QnAHome from './pages/qna/qnaList/page/QnAHome';
+
 function App() {
-  return <></>;
+  return <QnAHome />;
 }
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
-import QnAHome from './pages/qna/qnaList/page/QnAHome';
-
 function App() {
-  return <QnAHome />;
+  return <></>;
 }
 export default App;

--- a/src/pages/qna/qnaList/components/DeptFilter/DeptFilter.tsx
+++ b/src/pages/qna/qnaList/components/DeptFilter/DeptFilter.tsx
@@ -7,7 +7,7 @@ const DeptFilter = () => {
   const { showDeptList, selectedDept, toggleDeptList, selectDept } = useDeptFilter();
 
   return (
-    <div className="flex flex-col w-full ml-[1.25rem] mt-[1.25rem]">
+    <div className="flex flex-col w-[20.9375rem] mt-[1.25rem]">
       <button type="button" className="flex" onClick={toggleDeptList}>
         <span className="title-bold-20 text-CGray-1 mr-[4px]">진료과 전체</span>
         <Chevron
@@ -17,7 +17,7 @@ const DeptFilter = () => {
 
       {/* 추후 Framer Motion 등으로 애니메이션 구현 예정 */}
       {showDeptList && (
-        <div className="scrollbar-hide overflow-x-auto mt-[1.25rem]">
+        <div className="scrollbar-hide overflow-x-auto mt-[1.25rem] w-[20.9375rem]">
           <div className="flex flex-wrap gap-x-[.5rem] gap-y-[.75rem] min-w-[71.875rem] px-4 py-2">
             {deptList.map(dept => (
               <DeptBox

--- a/src/pages/qna/qnaList/components/QnA/QnAList.tsx
+++ b/src/pages/qna/qnaList/components/QnA/QnAList.tsx
@@ -2,7 +2,7 @@ import QnAListItem from './QnAListItem';
 
 const QnAList = () => {
   return (
-    <div className="flex flex-col gap-[3rem] mt-[1.875rem]">
+    <div className="flex flex-col gap-[3rem] mt-[1.875rem] mb-[5rem]">
       {Array.from({ length: 8 }).map((_, idx) => (
         <QnAListItem
           key={idx}

--- a/src/pages/qna/qnaList/page/QnAHome.tsx
+++ b/src/pages/qna/qnaList/page/QnAHome.tsx
@@ -1,11 +1,32 @@
 import DeptFilter from '@pages/qna/qnaList/components/DeptFilter/DeptFilter';
 import QnAList from '@pages/qna/qnaList/components/QnA/QnAList';
+import QnAButton from '@/shared/components/QnAButton';
 
 const QnAHome = () => {
   return (
-    <div className="flex flex-col justify-center items-center">
+    <div className="flex flex-col justify-center items-center mb-[100px]">
       <DeptFilter />
       <QnAList />
+      <QnAButton
+        text="질문 더보기"
+        font="title-semi-16"
+        textColor="text-CGray-3"
+        backgroundColor="bg-CGray-8"
+        width="w-[20.9375rem]"
+        px="px-[7.5rem]"
+        py="py-[1rem]"
+      />
+      <QnAButton
+        text="질문하기"
+        font="title-semi-16"
+        textColor="text-White"
+        backgroundColor="bg-Mainblue"
+        width="w-[20.9375rem]"
+        px="px-[7.5rem]"
+        py="py-[1rem]"
+        position="fixed"
+        bottom="bottom-[2rem]"
+      />
     </div>
   );
 };

--- a/src/pages/qna/qnaList/page/QnAHome.tsx
+++ b/src/pages/qna/qnaList/page/QnAHome.tsx
@@ -4,7 +4,7 @@ import QnAButton from '@/shared/components/QnAButton';
 
 const QnAHome = () => {
   return (
-    <div className="flex flex-col justify-center items-center mb-[100px]">
+    <div className="flex flex-col justify-center items-center mb-[6.25rem]">
       <DeptFilter />
       <QnAList />
       <QnAButton

--- a/src/shared/components/QnAButton.tsx
+++ b/src/shared/components/QnAButton.tsx
@@ -1,0 +1,35 @@
+interface QnAButtonProps {
+  text: string;
+  font: string; // ex: 'title-semi-18'
+  textColor: string; // ex: 'text-CGray'
+  backgroundColor: string; // ex: 'bg-White'
+  width: string; // ex: 'w-full' or 'w-[100px]'
+  px: string; // ex: 'px-[1rem]'
+  py: string; // ex: 'py-[0.5rem]'
+  position?: string; // fixed 등
+  bottom?: string;
+  left?: string;
+}
+
+const QnAButton = ({
+  text,
+  font,
+  textColor,
+  backgroundColor,
+  width,
+  px,
+  py,
+  position = '',
+  bottom = '',
+}: QnAButtonProps) => {
+  const className = `flex justify-center items-center rounded-[8px] 
+    ${font} ${textColor} ${backgroundColor} ${width} ${px} ${py} ${position} ${bottom}`;
+
+  return (
+    <button type="button" className={className}>
+      {text}
+    </button>
+  );
+};
+
+export default QnAButton;

--- a/src/shared/components/QnAButton.tsx
+++ b/src/shared/components/QnAButton.tsx
@@ -8,7 +8,6 @@ interface QnAButtonProps {
   py: string; // ex: 'py-[0.5rem]'
   position?: string; // fixed 등
   bottom?: string;
-  left?: string;
 }
 
 const QnAButton = ({

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,4 +12,5 @@ export default {
     },
   },
   plugins: [scrollbarHide],
+  safelist: ['text-white', 'text-CGray', 'text-CGray-3', 'bg-Mainblue', 'bg-White'],
 };


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #56 

### 💻 작업한 내용
- 질문하기, 질문 더보기 버튼 컴포넌트를 공통 컴포넌트로 구현했습니다.
- '진료과 조회' 드롭다운 컴포넌트의 레이아웃 배치를 수정했습니다.

### 📢 PR Point
- 질문하기, 질문 더보기 이외에도 여러 페이지와 컴포넌트에서 해당 버튼 스타일이 사용되는 것 같아 공통 컴포넌트로 생성했습니다.
    - 공통 버튼 컴포넌트 사용을 위해 버튼 배경색, 글자색 등을 동적으로 전달해줘야 합니다. 하지만 tailwind는 퍼포먼스를 위해 '프로젝트에서 실제로 사용된 클래스'만 css로 빌드하므로, 사용자 정의 동적 문자열이나 변수로 선언된 클래스명(bg-CGray-8 등)은 빌드에서 빠져 css가 적용되지 않는다는 문제가 있다고 합니다.
    - 이를 해결하기 위해 config파일에 'safelist'를 선언해 tailwind가 강제로 포함할 클래스를 지정했습니다.
    - 이 외에도 clsx 라이브러리를 설치해 조건부 UI를 구현하는 등의 방법도 있습니다.
    - 성능 면에서 어떤 방식이 부담이 덜 되는지는 잘 모르겠어서 좀 더 알아보면 좋을 것 같아요. 이번에는 safelist에 넣을 클래스가 많지 않아 이 방식으로 구현해봤습니다.

### 📸 스크린샷

https://github.com/user-attachments/assets/e89a0475-52f1-4cf6-8bfc-0db2741ae026
