### PR TITLE
Feat: QnA 공통 레이아웃 페이지(QnALayout) 생성 및 QnA 페이지 라우팅 설정

### DIFF
--- a/src/pages/qna/page/QnALayout.tsx
+++ b/src/pages/qna/page/QnALayout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router';
+import QnASearch from '../qnaList/components/QnASearch';
+import Footer from '@/shared/components/Footer';
+
+const QnALayout = () => {
+  return (
+    <div className="flex flex-col justify-center items-center mb-[9.1875rem]">
+      <QnASearch />
+      <main>
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default QnALayout;

--- a/src/pages/qna/qnaList/page/QnAHome.tsx
+++ b/src/pages/qna/qnaList/page/QnAHome.tsx
@@ -2,13 +2,10 @@ import DeptFilter from '@pages/qna/qnaList/components/DeptFilter';
 import QnAList from '@pages/qna/qnaList/components/QnAList';
 import QnAButton from '@/shared/components/QnAButton';
 import MyQuestion from '../components/MyQuestion';
-import QnASearch from '../components/QnASearch';
-import Footer from '@/shared/components/Footer';
 
 const QnAHome = () => {
   return (
-    <div className="flex flex-col justify-center items-center mb-[6.25rem]">
-      <QnASearch />
+    <div className="flex flex-col justify-center items-center mb-[2.25rem]">
       <DeptFilter />
       <MyQuestion />
       <QnAList />
@@ -21,7 +18,6 @@ const QnAHome = () => {
         px="px-[7.5rem]"
         py="py-[1rem]"
       />
-      <Footer />
       <QnAButton
         text="질문하기"
         font="title-semi-16"

--- a/src/pages/qna/qnaMy/page/QnAMy.tsx
+++ b/src/pages/qna/qnaMy/page/QnAMy.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const QnAMy = () => {
   return <div></div>;
 };

--- a/src/pages/qna/qnaMy/page/QnAMy.tsx
+++ b/src/pages/qna/qnaMy/page/QnAMy.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const QnAMy = () => {
+  return <div></div>;
+};
+
+export default QnAMy;

--- a/src/shared/components/Footer.tsx
+++ b/src/shared/components/Footer.tsx
@@ -2,7 +2,7 @@ import ImageMark from '@shared/assets/svg/ImageMark.svg?react';
 
 const Footer = () => {
   return (
-    <footer className="w-full flex flex-col justify-start mt-[2.25rem] mb-[7.0625rem]">
+    <footer className="w-full flex flex-col justify-start">
       <div className="w-full h-[.0625rem] border-t border-[#ECEDF0]"></div>
 
       <div className="flex flex-col mt-[5rem] ml-[1.25rem] gap-[2.25rem]">

--- a/src/shared/router/Router.tsx
+++ b/src/shared/router/Router.tsx
@@ -1,7 +1,9 @@
 import { createBrowserRouter } from 'react-router-dom';
 import ChatPage from '@/pages/chat/page/ChatPage';
-import QnAList from '@/pages/qna/qnaList/components/QnAList';
 import QnaDetail from '@/pages/qna/qnaDetail/page/QnaDetail';
+import QnALayout from '@/pages/qna/page/QnALayout';
+import QnAMy from '@/pages/qna/qnaMy/page/QnAMy';
+import QnAHome from '@/pages/qna/qnaList/page/QnAHome';
 
 const router = createBrowserRouter([
   {
@@ -20,11 +22,21 @@ const router = createBrowserRouter([
   },
   {
     path: '/qna',
-    element: <QnAList />,
-  },
-  {
-    path: '/qna/:id',
-    element: <QnaDetail />,
+    element: <QnALayout />,
+    children: [
+      {
+        index: true, // 기본 하위 라우트
+        element: <QnAHome />,
+      },
+      {
+        path: ':id',
+        element: <QnaDetail />,
+      },
+      {
+        path: 'my',
+        element: <QnAMy />,
+      },
+    ],
   },
 ]);
 


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #83 

### 💻 작업한 내용
- QnA 공통 레이아웃 페이지(QnALayout) 생성 및 QnA 페이지 라우팅을 적용했습니다.

### 📢 PR Point
- QnALayout 페이지
```
<div className="flex flex-col justify-center items-center mb-[9.1875rem]">
      <QnASearch />
      <main>
        <Outlet />
      </main>
      <Footer />
    </div>
```
   
Outlet: QnAHome, QnAList, QnAMy 페이지

### 📸 스크린샷
