### PR TITLE
Feat: 질병 상세 설명 메시지 박스 컴포넌트 구현(7번째 챗봇 박스)

### DIFF
--- a/src/pages/chat/components/chatBox/ChatAnswerBox.tsx
+++ b/src/pages/chat/components/chatBox/ChatAnswerBox.tsx
@@ -1,0 +1,18 @@
+// import { useRef, useState } from 'react';
+import { useRef } from 'react';
+import ChatBubbleBot from '@/pages/chat/components/chatBox/ChatBubbleBot';
+import { formatTime } from '@/shared/utils/date';
+
+// 디자인 더미 값(테스트용)
+const answer = [
+  '두드러기는 피부에 발생하는 발진으로, 주로 가려움증과 함께 나타납니다. 보통 알레르기 반응이나 특별한 자극에 의해 발생할 수 있으며, 다음과 같은 원인들이 있습니다. 1. 알레르기 요인: 특정 음식(예: 견과류, 해산물), 약물, 꽃가루 또는 동물의 털 등. 2. 물리적 자극: 차가운 온도, 더운 물, 압력 등. 3. 감염: 바이러스나 세균 감염으로 인한 반응. 4. 스트레스: 심리적 스트레스가 면역 체계에 영향을 줄 수 있습니다. 두드러기의 증상은 보통 일시적이며, 몇 시간에서 며칠 내에 자연스럽게 사라지는 경우가 많습니다. 치료는 주로 증상 완화에 중점을 두며, 항히스타민제가 많이 사용됩니다. 그러나 만약 두드러기가 지속되거나 심한 경우, 반드시 의료 전문가와 상담해야 합니다. 소아의 경우 특히 주의가 필요하며, 진단 및 치료에 있어 전문적인 도움을 받는 것이 중요합니다.',
+];
+
+const ChatAnswerBox = () => {
+  const timeRef = useRef(formatTime(new Date()));
+  // const [answer, setAnswer] = useState<string>('');
+
+  return <ChatBubbleBot message={<p className="body-med-14">{answer}</p>} time={timeRef.current} />;
+};
+
+export default ChatAnswerBox;

--- a/src/pages/chat/components/chatBox/ChatMedicationBox.tsx
+++ b/src/pages/chat/components/chatBox/ChatMedicationBox.tsx
@@ -1,6 +1,9 @@
+import { useRef } from 'react';
 import ChatBubbleBot from '@pages/chat/components/chatBox/ChatBubbleBot';
+import { formatTime } from '@/shared/utils/date';
 
 const ChatMedicationBox = () => {
+  const timeRef = useRef(formatTime(new Date()));
   return (
     <ChatBubbleBot
       message={
@@ -16,7 +19,7 @@ const ChatMedicationBox = () => {
           </ul>
         </div>
       }
-      time="오후 10:20" //수정 필요
+      time={timeRef.current}
     />
   );
 };


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #86 

### 💻 작업한 내용
- 사용자 입력 메시지 값에 대한 질병 상세 설명 메시지 박스 컴포넌트 구현했습니당
- 수정 예정이었던 `ChatMedicationBox.tsx` 내부 시간 값 실제 시간으로 변경했습니다

### 📢 PR Point
- 해당 부분은 API 연동 예정 부분으로, 현재는 디자인에 맞춰 더미 텍스트를 임시로 작성해두었습니다.
- API 응답에서 'answer' 필드 값을 사용할 예정이며 이에 맞춰 해당 변수도 answer로 선언해두었습니다.
<img width="724" alt="image" src="https://github.com/user-attachments/assets/24c52dd3-7123-40af-935d-a9bef3f85eba" />

### 📸 스크린샷
<img width="370" alt="스크린샷 2025-05-19 오후 8 27 23" src="https://github.com/user-attachments/assets/7e0b8461-f684-47b8-9dbf-00cae919223d" />
