### PR TITLE
Feat: 메인 뷰 및 메뉴 뷰 네비게이션 연결

### DIFF
--- a/src/pages/main/components/GoodBotFAB.tsx
+++ b/src/pages/main/components/GoodBotFAB.tsx
@@ -1,10 +1,15 @@
 import GoodBotFABImage from '@/shared/assets/images/ImgGoodbotFAB.png';
 
-const GoodBotFAB = () => {
+interface GoodBotFABProps {
+  onClick: () => void;
+}
+
+const GoodBotFAB = ({ onClick }: GoodBotFABProps) => {
   return (
     <button
       type="button"
       title="병원 더보기 버튼"
+      onClick={onClick}
       className="inline-flex items-center rounded-full bg-White border border-[#ECEDF0] shadow-[0_0px_20px_rgba(0,0,0,0.1)] py-[8px] pl-[20px] pr-[12px]"
     >
       <div className="flex flex-col gap-[2px]">

--- a/src/pages/main/components/MainHeader.tsx
+++ b/src/pages/main/components/MainHeader.tsx
@@ -3,7 +3,11 @@ import LogoHeader from '@/shared/assets/images/Logoheader.png';
 import IconMenu from '@/shared/assets/svg/IconMenu.svg?react';
 import IconSearch from '@/shared/assets/svg/IconSearch.svg?react';
 
-const MainHeader = () => {
+interface MainHeaderProps {
+  onClick: () => void;
+}
+
+const MainHeader = ({ onClick }: MainHeaderProps) => {
   const [query, setQuery] = useState('');
 
   return (
@@ -23,7 +27,7 @@ const MainHeader = () => {
           </div>
         )}
       </div>
-      <button type="button" className="border-none">
+      <button type="button" onClick={onClick} className="border-none">
         <IconMenu className="w-[2.25rem] h-[2.25rem]" />
       </button>
     </header>

--- a/src/pages/main/page/MainPage.tsx
+++ b/src/pages/main/page/MainPage.tsx
@@ -11,16 +11,27 @@ import GoodBotFAB from '@/pages/main/components/GoodBotFAB';
 import PromotionBanner from '@/shared/components/PromotionBanner';
 import { dummyHospitals } from '@/shared/constants/hospitals';
 import { usePagination } from '@/pages/main/hooks/UsePagination';
+import { useNavigate } from 'react-router';
 
 const MainPage = () => {
   const { data: hospitals, hasMore, loadMore } = usePagination(dummyHospitals, 7);
+
+  const navigate = useNavigate();
+
+  const handleMenuClick = () => {
+    navigate('/menu');
+  };
+
+  const handleGoodBotClick = () => {
+    navigate('/chat');
+  };
 
   return (
     <div>
       <PromotionBanner />
       <div className="flex flex-col gap-[1rem]">
         <div className="flex flex-col gap-[1.5rem] pt-[.75rem] px-[1.25rem]">
-          <MainHeader />
+          <MainHeader onClick={handleMenuClick} />
           <LocationCategoryFilter />
         </div>
         <div className="flex overflow-x-auto scrollbar-hide gap-[.5rem] px-[1.25rem]">
@@ -43,7 +54,7 @@ const MainPage = () => {
       <Footer />
 
       <div className="fixed bottom-[4.625rem] right-[1.25rem]">
-        <GoodBotFAB />
+        <GoodBotFAB onClick={handleGoodBotClick} />
       </div>
     </div>
   );

--- a/src/pages/menu/components/MenuButton.tsx
+++ b/src/pages/menu/components/MenuButton.tsx
@@ -1,11 +1,12 @@
 interface MenuButtonProps {
   icon: string;
   name: string;
+  onClick?: () => void;
 }
 
-const MenuButton = ({ icon, name }: MenuButtonProps) => {
+const MenuButton = ({ icon, name, onClick }: MenuButtonProps) => {
   return (
-    <button type="button" className="flex items-center gap-[1rem]">
+    <button type="button" onClick={onClick} className="flex items-center gap-[1rem]">
       <img src={icon} />
       <span className="title-semi-16 text-CGray-1">{name}</span>
     </button>

--- a/src/pages/menu/page/MenuPage.tsx
+++ b/src/pages/menu/page/MenuPage.tsx
@@ -6,11 +6,22 @@ import MenuButton from '@/pages/menu/components/MenuButton';
 import HospitalIcon from '@/shared/assets/svg/IconHospitalLine.svg';
 import TalkIcon from '@/shared/assets/svg/IconTalk.svg';
 import QnaIcon from '@/shared/assets/svg/IconQna.svg';
+import { useNavigate } from 'react-router';
 
 const MenuPage = () => {
+  const navigate = useNavigate();
+
+  const handleBackClick = () => {
+    navigate('/');
+  };
+
+  const handleQnAClick = () => {
+    navigate('/qna');
+  };
+
   return (
     <div className="h-screen flex flex-col pt-[1.5rem] px-[1.25rem]">
-      <button type="button">
+      <button onClick={handleBackClick} type="button">
         <BackArrowIcon />
       </button>
       <img src={LogoText} className="w-[6.25rem] h-[2rem] mt-[1rem] mb-[3rem]" />
@@ -21,7 +32,7 @@ const MenuPage = () => {
       <div className="flex flex-col gap-[1.5rem] mt-[2rem]">
         <MenuButton icon={HospitalIcon} name="병원 찾기" />
         <MenuButton icon={TalkIcon} name="AI 건강 상담" />
-        <MenuButton icon={QnaIcon} name="Q&A" />
+        <MenuButton icon={QnaIcon} name="Q&A" onClick={handleQnAClick} />
       </div>
     </div>
   );

--- a/src/shared/router/Router.tsx
+++ b/src/shared/router/Router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
+import MainPage from '@/pages/main/page/MainPage';
+import MenuPage from '@/pages/menu/page/MenuPage';
 import ChatPage from '@/pages/chat/page/ChatPage';
-import QnAList from '@/pages/qna/qnaList/components/QnAList';
 import QnADetail from '@/pages/qna/qnaDetail/page/QnaDetail';
 import QnALayout from '@/pages/qna/page/QnALayout';
 import QnAMy from '@/pages/qna/qnaMy/page/QnAMy';
@@ -8,14 +9,12 @@ import QnAHome from '@/pages/qna/qnaList/page/QnAHome';
 
 const router = createBrowserRouter([
   {
-    // 메인 페이지로 변경
     path: '/',
-    // element: < />,
+    element: <MainPage />,
   },
   {
-    // 메뉴 페이지로 변경
     path: '/menu',
-    // element: < />,
+    element: <MenuPage />,
   },
   {
     path: '/chat',
@@ -32,7 +31,7 @@ const router = createBrowserRouter([
       },
       {
         path: ':id',
-        element: <QnaDetail />,
+        element: <QnADetail />,
       },
       {
         path: 'my',


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #97 

### 💻 작업한 내용
- 라우터에서 메인 뷰와 메뉴 뷰 주석 지우고 설정 추가했어요!
- 메인 뷰에서 메뉴 뷰 이동, 메인 뷰에서 챗 뷰 이동 구현했어요
- 메뉴 뷰에서 뒤로가기 이동, 메뉴 뷰에서 QnA 뷰 이동 구현했어요

### 📢 PR Point
- 따로 없습니당

### 📸 스크린샷
https://github.com/user-attachments/assets/27b8abd5-bda8-46b0-9616-544a945e1fa3

