### PR TITLE
Api: 메인 페이지 API 연동

### DIFF
--- a/src/pages/main/components/HospitalListItem.tsx
+++ b/src/pages/main/components/HospitalListItem.tsx
@@ -24,6 +24,8 @@ const HospitalListItem = ({
   review,
   image,
 }: HospitalInfo) => {
+  const displayCloseAt = closeAt ? closeAt.split(':').slice(0, 2).join(':') : '–';
+
   return (
     <div className="flex justify-between">
       <div className="flex flex-col gap-[9px]">
@@ -33,7 +35,7 @@ const HospitalListItem = ({
             {isOpen && (
               <>
                 <span className="title-semi-14 text-SoftGreen">진료중</span>
-                <span className="title-med-14 text-WGray-1">{closeAt} 진료종료</span>
+                <span className="title-med-14 text-WGray-1">{displayCloseAt} 진료종료</span>
               </>
             )}
             {!isOpen && <span className="title-semi-14 text-WGray-1">진료시간 병원 문의</span>}

--- a/src/pages/main/components/HospitalListItem.tsx
+++ b/src/pages/main/components/HospitalListItem.tsx
@@ -28,10 +28,10 @@ const HospitalListItem = ({
 
   return (
     <div className="flex justify-between">
-      <div className="flex flex-col gap-[9px]">
+      <div className="flex flex-col gap-[.5625rem]">
         <span className="title-bold-18 text-SoftBlack">{name}</span>
-        <div className="flex flex-col gap-[5px]">
-          <div className="flex items-center gap-[13px]">
+        <div className="flex flex-col gap-[.3125rem]">
+          <div className="flex items-center gap-[.8125rem]">
             {isOpen && (
               <>
                 <span className="title-semi-14 text-SoftGreen">진료중</span>
@@ -40,13 +40,13 @@ const HospitalListItem = ({
             )}
             {!isOpen && <span className="title-semi-14 text-WGray-1">진료시간 병원 문의</span>}
           </div>
-          <div className="flex items-center gap-[14px]">
+          <div className="flex items-center gap-[.875rem]">
             <span className="title-bold-14 text-SoftBlack">{distance}km</span>
             <span className="title-med-14 text-WGray-1">{address}</span>
           </div>
         </div>
-        <div className="flex items-center gap-[13px]">
-          <div className="flex items-center gap-[2px]">
+        <div className="flex items-center gap-[.8125rem]">
+          <div className="flex items-center gap-[.125rem]">
             {review && (
               <>
                 <IconStarBlack />
@@ -64,9 +64,9 @@ const HospitalListItem = ({
         </div>
       </div>
       {image ? (
-        <img src={image} className="w-[76px] h-[76px] rounded-[.375rem]" />
+        <img src={image} className="w-[4.75rem] h-[4.75rem] rounded-[6px]" />
       ) : (
-        <img src={ImgHospitalEmpty} className="w-[76px] h-[76px]" />
+        <img src={ImgHospitalEmpty} className="w-[4.75rem] h-[4.75rem]" />
       )}
     </div>
   );

--- a/src/pages/main/components/HospitalListItem.tsx
+++ b/src/pages/main/components/HospitalListItem.tsx
@@ -26,10 +26,10 @@ const HospitalListItem = ({
 }: HospitalInfo) => {
   return (
     <div className="flex justify-between">
-      <div className="flex flex-col gap-[.5625rem]">
+      <div className="flex flex-col gap-[9px]">
         <span className="title-bold-18 text-SoftBlack">{name}</span>
-        <div className="flex flex-col gap-[.3125rem]">
-          <div className="flex items-center gap-[.8125rem]">
+        <div className="flex flex-col gap-[5px]">
+          <div className="flex items-center gap-[13px]">
             {isOpen && (
               <>
                 <span className="title-semi-14 text-SoftGreen">진료중</span>
@@ -38,13 +38,13 @@ const HospitalListItem = ({
             )}
             {!isOpen && <span className="title-semi-14 text-WGray-1">진료시간 병원 문의</span>}
           </div>
-          <div className="flex items-center gap-[.875rem]">
+          <div className="flex items-center gap-[14px]">
             <span className="title-bold-14 text-SoftBlack">{distance}km</span>
             <span className="title-med-14 text-WGray-1">{address}</span>
           </div>
         </div>
-        <div className="flex items-center gap-[.8125rem]">
-          <div className="flex items-center gap-[.125rem]">
+        <div className="flex items-center gap-[13px]">
+          <div className="flex items-center gap-[2px]">
             {review && (
               <>
                 <IconStarBlack />
@@ -62,9 +62,9 @@ const HospitalListItem = ({
         </div>
       </div>
       {image ? (
-        <img src={image} className="w-[4.75rem] h-[4.75rem]" />
+        <img src={image} className="w-[76px] h-[76px] rounded-[.375rem]" />
       ) : (
-        <img src={ImgHospitalEmpty} className="w-[4.75rem] h-[4.75rem]" />
+        <img src={ImgHospitalEmpty} className="w-[76px] h-[76px]" />
       )}
     </div>
   );

--- a/src/pages/main/page/MainPage.tsx
+++ b/src/pages/main/page/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import FilterChip from '@/pages/main/components/FilterChip';
 import LocationCategoryFilter from '@/pages/main/components/LocationCategoryFilter';
 import MainHeader from '@/pages/main/components/MainHeader';
@@ -9,22 +10,28 @@ import HospitalListItem from '@/pages/main/components/HospitalListItem';
 import Footer from '@/shared/components/Footer';
 import GoodBotFAB from '@/pages/main/components/GoodBotFAB';
 import PromotionBanner from '@/shared/components/PromotionBanner';
-import { dummyHospitals } from '@/shared/constants/hospitals';
+import type { HospitalInfo } from '@/pages/main/components/HospitalListItem';
 import { usePagination } from '@/pages/main/hooks/UsePagination';
 import { useNavigate } from 'react-router';
+import { fetchHospitalInfo } from '@/shared/apis/main/HospitalInfoAPI';
 
 const MainPage = () => {
-  const { data: hospitals, hasMore, loadMore } = usePagination(dummyHospitals, 7);
+  const [items, setItems] = useState<HospitalInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchHospitalInfo()
+      .then(data => setItems(data))
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const { data: hospitals, hasMore, loadMore } = usePagination(items, 7);
 
   const navigate = useNavigate();
-
-  const handleMenuClick = () => {
-    navigate('/menu');
-  };
-
-  const handleGoodBotClick = () => {
-    navigate('/chat');
-  };
+  const handleMenuClick = () => navigate('/menu');
+  const handleGoodBotClick = () => navigate('/chat');
 
   return (
     <div>
@@ -43,12 +50,14 @@ const MainPage = () => {
       </div>
 
       <section className="flex flex-col gap-[5rem] px-[1.25rem] mt-[3rem] mb-[2.25rem]">
+        {loading && <div className="text-center">로딩 중</div>}
+        {error && <div className="text-center">에러: {error}</div>}
+
         <div className="flex flex-col gap-[3rem]">
-          {hospitals.map(hospital => (
-            <HospitalListItem key={hospital.id} {...hospital} />
-          ))}
+          {!loading &&
+            hospitals.map(hospital => <HospitalListItem key={hospital.id} {...hospital} />)}
         </div>
-        {hasMore && <MoreButton onClick={loadMore} />}
+        {!loading && hasMore && <MoreButton onClick={loadMore} />}
       </section>
 
       <Footer />

--- a/src/shared/apis/main/HospitalInfoAPI.ts
+++ b/src/shared/apis/main/HospitalInfoAPI.ts
@@ -1,0 +1,14 @@
+import apiClient from '@/shared/apis/apiClient';
+import type { HospitalInfo } from '@/pages/main/components/HospitalListItem';
+
+export interface HospitalInfoResponse {
+  statusCode: number;
+  message: string;
+  data: { hospitals: HospitalInfo[] };
+}
+
+export const fetchHospitalInfo = async (): Promise<HospitalInfo[]> => {
+  const response = await apiClient.get<HospitalInfoResponse>('/hospitals');
+
+  return response.data.data.hospitals;
+};


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #105 

### 💻 작업한 내용
- 메인 페이지에 병원 정보 리스트를 GET하는 API를 연동했습니다!

### 📢 PR Point
- 기존에 더미데이터를 만드는 과정에서 명세서와 동일한 타입의 interface를 생성해 두었기에, 해당 인터페이스를 재사용하고자 했습니다! (그런데 요 인터페이스의 선언이 컴포넌트 파일에 있는 것이 맞는지 잘 모르겠습니다! 메인 페이지 파일과 API 파일에서 해당 인터페이스를 import해서 쓰고 있는데 더 좋은 선언 위치가 있을지 고민됩니다 ㅎㅎ)
- 웹에서 API 연동 처음해봤는데 맞는 방식인지 잘 모르겠네요 ⋯ 😅

### 📸 스크린샷
https://github.com/user-attachments/assets/c9b1841e-cd2e-4b56-aeb1-326e58160bb9

