### PR TITLE
Api: 채팅 페이지 api 연동

### DIFF
--- a/src/pages/chat/components/ChatBody.tsx
+++ b/src/pages/chat/components/ChatBody.tsx
@@ -1,7 +1,11 @@
 import { useRef, useState, useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { useUserStartTime } from '../hooks/useUserStartTime';
 import { useAutoScrollToBottom } from '../hooks/useAutoScrollToBottom';
 import { NOTICE_MESSAGE, START_MESSAGE } from '@shared/constants/chatMessages';
+import { postChat } from '@/shared/apis/chat/chatApi';
+import { handleApiError } from '@/shared/apis/chat/errorHandler';
+
 import Alert from '@shared/assets/svg/chatAlert.svg?react';
 import ChatWelcomeBox from '@/pages/chat/components/chatBox/ChatWelcomeBox';
 import ChatQuestionBox from './chatBox/ChatQuestionBox';
@@ -9,10 +13,19 @@ import ChatConsiderationBox from './chatBox/ChatConsiderationBox';
 import ChatImageBox from './chatBox/ChatImageBox';
 import ChatUser from './user/ChatUser';
 import NextQuestionButton from './NextQuestionButton';
+import ChatAnswerBox from './chatBox/ChatAnswerBox';
+import ChatSummaryBox from './chatBox/ChatSummaryBox';
+import ChatLoadingBox from './chatBox/ChatLoadingBox';
 
 interface Message {
   text: string;
   timestamp: string;
+}
+
+interface ChatResponse {
+  answer: string;
+  summary: string;
+  department: string;
 }
 
 interface ChatBodyProps {
@@ -26,9 +39,11 @@ const ChatBody: React.FC<ChatBodyProps> = ({ messages }) => {
   const [selectedOptionTime, setSelectedOptionTime] = useState<string>('');
   const [hasUploadedImage, setHasUploadedImage] = useState(false);
   const [imageCount, setImageCount] = useState(0);
+  const [imageFiles, setImageFiles] = useState<File[]>([]);
   const [formattedMessages, setFormattedMessages] = useState<Message[]>([]);
+  const [chatResult, setChatResult] = useState<ChatResponse | null>(null);
+  const [isLoadingAnswer, setIsLoadingAnswer] = useState(false);
   const prevMessagesLengthRef = useRef<number>(0);
-
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { getStartTime, setStartTime, getCurrentTime } = useUserStartTime();
 
@@ -38,7 +53,24 @@ const ChatBody: React.FC<ChatBodyProps> = ({ messages }) => {
     hasUploadedImage,
     imageCount,
     showNextQuestion,
+    chatResult,
   ]);
+
+  const mutation = useMutation({
+    mutationFn: postChat,
+    onMutate: () => {
+      setIsLoadingAnswer(true);
+      setChatResult(null);
+    },
+    onSuccess: data => {
+      setChatResult(data);
+      setIsLoadingAnswer(false);
+    },
+    onError: error => {
+      handleApiError(error);
+      setIsLoadingAnswer(false);
+    },
+  });
 
   const handleStart = () => {
     setStartTime();
@@ -46,7 +78,14 @@ const ChatBody: React.FC<ChatBodyProps> = ({ messages }) => {
   };
 
   const handleNextQuestionClick = () => {
-    console.log('다음 질문 진행');
+    if (!selectedOption || formattedMessages.length === 0) {
+      return;
+    }
+    mutation.mutate({
+      question: formattedMessages.map(m => m.text).join('\n'),
+      detail: selectedOption,
+      files: imageFiles,
+    });
   };
 
   const handleSelectOption = (option: string) => {
@@ -85,10 +124,8 @@ const ChatBody: React.FC<ChatBodyProps> = ({ messages }) => {
             <ChatUser message={selectedOption} time={selectedOptionTime} />
             <ChatImageBox
               onImageUpload={() => setHasUploadedImage(true)}
-              onImageCountChange={count => {
-                setImageCount(count);
-                if (count === 3) console.log('이미지 3장 업로드 완료!');
-              }}
+              onImageCountChange={count => setImageCount(count)}
+              onFilesChange={setImageFiles}
             />
             {hasUploadedImage && imageCount < 3 && (
               <NextQuestionButton onClick={handleNextQuestionClick} />
@@ -104,10 +141,22 @@ const ChatBody: React.FC<ChatBodyProps> = ({ messages }) => {
       <ChatUser message={START_MESSAGE} time={getStartTime()} />
       <ChatQuestionBox />
       {renderMessages()}
+
       {!showNextQuestion && formattedMessages.length > 0 && (
         <NextQuestionButton onClick={() => setShowNextQuestion(true)} />
       )}
+
       {renderQuestionFlow()}
+
+      {isLoadingAnswer && <ChatLoadingBox />}
+
+      {!isLoadingAnswer && chatResult && (
+        <>
+          <ChatAnswerBox answer={chatResult.answer} />
+          <ChatSummaryBox summary={chatResult.summary} department={chatResult.department} />
+        </>
+      )}
+
       <div ref={scrollRef} />
     </>
   );

--- a/src/pages/chat/components/chatBox/ChatAnswerBox.tsx
+++ b/src/pages/chat/components/chatBox/ChatAnswerBox.tsx
@@ -1,16 +1,9 @@
-// import { useRef, useState } from 'react';
 import { useRef } from 'react';
 import ChatBubbleBot from '@/pages/chat/components/chatBox/ChatBubbleBot';
 import { formatTime } from '@/shared/utils/date';
 
-// 디자인 더미 값(테스트용)
-const answer = [
-  '두드러기는 피부에 발생하는 발진으로, 주로 가려움증과 함께 나타납니다. 보통 알레르기 반응이나 특별한 자극에 의해 발생할 수 있으며, 다음과 같은 원인들이 있습니다. 1. 알레르기 요인: 특정 음식(예: 견과류, 해산물), 약물, 꽃가루 또는 동물의 털 등. 2. 물리적 자극: 차가운 온도, 더운 물, 압력 등. 3. 감염: 바이러스나 세균 감염으로 인한 반응. 4. 스트레스: 심리적 스트레스가 면역 체계에 영향을 줄 수 있습니다. 두드러기의 증상은 보통 일시적이며, 몇 시간에서 며칠 내에 자연스럽게 사라지는 경우가 많습니다. 치료는 주로 증상 완화에 중점을 두며, 항히스타민제가 많이 사용됩니다. 그러나 만약 두드러기가 지속되거나 심한 경우, 반드시 의료 전문가와 상담해야 합니다. 소아의 경우 특히 주의가 필요하며, 진단 및 치료에 있어 전문적인 도움을 받는 것이 중요합니다.',
-];
-
-const ChatAnswerBox = () => {
+const ChatAnswerBox = ({ answer }: { answer: string }) => {
   const timeRef = useRef(formatTime(new Date()));
-  // const [answer, setAnswer] = useState<string>('');
 
   return <ChatBubbleBot message={<p className="body-med-14">{answer}</p>} time={timeRef.current} />;
 };

--- a/src/pages/chat/components/chatBox/ChatImageBox.tsx
+++ b/src/pages/chat/components/chatBox/ChatImageBox.tsx
@@ -8,9 +8,14 @@ import { formatTime } from '@/shared/utils/date';
 interface ChatImageBoxProps {
   onImageUpload?: () => void;
   onImageCountChange?: (count: number) => void;
+  onFilesChange?: (files: File[]) => void;
 }
 
-const ChatImageBox: React.FC<ChatImageBoxProps> = ({ onImageUpload, onImageCountChange }) => {
+const ChatImageBox: React.FC<ChatImageBoxProps> = ({
+  onImageUpload,
+  onImageCountChange,
+  onFilesChange,
+}) => {
   const timeRef = useRef(formatTime(new Date()));
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -46,6 +51,10 @@ const ChatImageBox: React.FC<ChatImageBoxProps> = ({ onImageUpload, onImageCount
 
     if (onImageCountChange) {
       onImageCountChange(newImages.length);
+    }
+
+    if (onFilesChange) {
+      onFilesChange(newImages);
     }
   };
 

--- a/src/pages/chat/components/chatBox/ChatSummaryBox.tsx
+++ b/src/pages/chat/components/chatBox/ChatSummaryBox.tsx
@@ -1,23 +1,14 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef } from 'react';
 import ChatBubbleBot from '@/pages/chat/components/chatBox/ChatBubbleBot';
 import Button from '@pages/chat/components/Button';
 import { formatTime } from '@/shared/utils/date';
+interface ChatSummaryBoxProps {
+  summary: string;
+  department: string;
+}
 
-const ChatSummaryBox = () => {
+const ChatSummaryBox: React.FC<ChatSummaryBoxProps> = ({ summary, department }) => {
   const timeRef = useRef(formatTime(new Date()));
-  const [summary, setSummary] = useState('');
-  const [department, setDepartment] = useState('');
-
-  useEffect(() => {
-    const mock = {
-      data: {
-        summary: '두드러기는 가려움증을 동반하고 대개 일시적이지만 지속 시 치료가 필요합니다.',
-        department: '피부과 또는 내과 (소아의 경우 소아청소년과)',
-      },
-    };
-    setSummary(mock.data.summary);
-    setDepartment(mock.data.department);
-  }, []);
 
   return (
     <div>

--- a/src/pages/chat/hooks/useChatMutation.ts
+++ b/src/pages/chat/hooks/useChatMutation.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { postChat } from '@/shared/apis/chat/chatApi';
+import type { ChatResponse, ChatRequest } from '@/shared/apis/chat/chatApi';
+import { handleApiError } from '@/shared/apis/chat/errorHandler';
+import { useState } from 'react';
+
+export const useChatMutation = () => {
+  const [chatResult, setChatResult] = useState<ChatResponse | null>(null);
+
+  const mutation = useMutation<ChatResponse, Error, ChatRequest>({
+    mutationFn: postChat,
+    onSuccess: data => {
+      setChatResult(data);
+    },
+    onError: handleApiError,
+  });
+
+  return { mutation, chatResult };
+};

--- a/src/shared/apis/chat/chatApi.ts
+++ b/src/shared/apis/chat/chatApi.ts
@@ -1,0 +1,26 @@
+import { apiClient } from '@/shared/apis/apiClient';
+
+export interface ChatRequest {
+  files: File[];
+  question: string;
+  detail: string;
+}
+
+export interface ChatResponse {
+  answer: string;
+  summary: string;
+  department: string;
+}
+
+export const postChat = async (data: ChatRequest): Promise<ChatResponse> => {
+  const formData = new FormData();
+  data.files.forEach(file => formData.append('files', file));
+  formData.append('question', data.question);
+  formData.append('detail', data.detail);
+
+  const response = await apiClient.post('/qna', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+
+  return response.data.data;
+};

--- a/src/shared/apis/chat/errorHandler.ts
+++ b/src/shared/apis/chat/errorHandler.ts
@@ -1,0 +1,9 @@
+export const handleApiError = (error: unknown) => {
+  if (error instanceof Error) {
+    console.error('❌ API Error:', error.message);
+    alert(`문제가 발생했어요: ${error.message}`);
+  } else {
+    console.error('❌ Unknown error:', error);
+    alert('알 수 없는 오류가 발생했어요.');
+  }
+};


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #103 

### 💻 작업한 내용
- 채팅 api 연동했습니다!
- 채팅 로직 구현(이미지 업로드 흐름 이후 로딩 및 응답 로직): 
   ChatBody.tsx 내에 loading, answer, summary 컴포넌트 import하고, 답변 준비중에는 로딩 컴포넌트 나오도록 작성했습니다
- 에러 핸들러 파일과, uaeMutation 훅 파일 추가 생성했습니다
- ChatAnswerBox.tsx와 ChatSummmaryBox.tsx 파일 내에 작성되었던, 더미 값 삭제 후 api 연동 로직에 맞도록 수정했습니다

### 📢 PR Point
- 유저가 메시지를 보내면 마지막 글자가 한 번 더 나오고 있어서 점검이 필요할 것 같습니다!

### 📸 스크린샷

https://github.com/user-attachments/assets/ce2fddef-5d13-46de-a379-f8b6c9b3bd3e

