### PR TITLE
Fix: 문자 포맷팅 함수 수정

### DIFF
--- a/src/shared/utils/formatText.tsx
+++ b/src/shared/utils/formatText.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react';
 
 export const formatText = (content: string): JSX.Element[] => {
-  const sentences = content.split(/(?<=[.?!])\s+/);
+  const sentences = content.split(/(?<=[.?!:])\s+(?=\d+\.)/);
   const result: (string | null)[] = [];
 
   let currentNumberedItem: string | null = null;


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #81 

### 💻 작업한 내용
- "원인은 다음과 같습니다: 1." 이렇게 줄바꿈이 제대로 되지 않아서 포맷팅 함수 수정했습니다
`const sentences = content.split(/(?<=[.?!:])\s+(?=\d+\.)/);
`
기존 정규식을 보완해 : 뒤에 숫자 목록이 나오는 경우도 문장 분리 대상이 되도록 수정했습니다.

### 📢 PR Point
- 바로 머지할게요~

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/f4ca90c3-eadf-4c75-be95-3f7acd433e54)