### PR TITLE
Fix: 아이콘 수직 정렬

### DIFF
--- a/src/pages/qna/qnaList/components/QnAListItem.tsx
+++ b/src/pages/qna/qnaList/components/QnAListItem.tsx
@@ -17,7 +17,7 @@ const QnAListItem = ({ id, title, summary, department, timeElapsed }: QnAPreview
     >
       <div className="flex gap-[.5rem] text-CGray-4">
         <span className="caption-semi-13">{department}</span>
-        <Ellipsis />
+        <Ellipsis className="self-center" />
         <span className="caption-reg-13">{timeElapsed}</span>
       </div>
 


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #26 

### 💻 작업한 내용
- department와 timeElapsed 텍스트 사이에서 Ellipsis 아이콘이 가운데 정렬이 안 되어 있어서 수정했습니다.
![image](https://github.com/user-attachments/assets/f7f720da-3a0e-457d-82ef-fe48fefbe70e)

### 📢 PR Point
- 너무 사소한 거라 .. 머지합니다 

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/3ed3829e-e180-4449-9a51-9b9c6ab44fb1)
